### PR TITLE
Manually updating version number for CDS FE

### DIFF
--- a/deployments.yaml
+++ b/deployments.yaml
@@ -6,9 +6,9 @@ services:
     image: 24.6.1.148
     buildNumber: '148'
   frontend:
-    version: 3.0.4.165
-    image: 3.0.4.165
-    buildNumber: '165'
+    version: 3.0.4.162
+    image: 3.0.4.162
+    buildNumber: '162'
   files:
     version: main.35
     image: main.35


### PR DESCRIPTION
Build number FE 165 includes Government Shutdown banner. Reverting back to FE 162 build which does not have Government Shutdown banner.